### PR TITLE
Add pseudo time travel

### DIFF
--- a/game2/src/Canvas.fs
+++ b/game2/src/Canvas.fs
@@ -9,6 +9,7 @@ type private MainLoop =
     abstract setDraw: (float -> unit) -> MainLoop
     abstract setEnd: (float -> bool -> unit) -> MainLoop
     abstract start: unit -> unit
+    abstract stop: unit -> unit
     abstract getFPS: unit -> float
     abstract getMaxAllowedFPS: unit -> float
     abstract setMaxAllowedFPS: float -> unit
@@ -18,7 +19,12 @@ type private MainLoop =
 
 type Context = Browser.CanvasRenderingContext2D
 type Update<'Msg, 'Model> = 'Model -> 'Msg -> 'Model
-type View<'Model> = 'Model -> Context -> float -> unit
+type View<'Model> = 'Model -> Context -> unit
+
+type CanvasControls<'Model, 'CacheModel> =
+    abstract IsPaused: bool
+    abstract TogglePause: unit -> unit
+    abstract RevertState: reverter:('Model -> 'CacheModel -> 'Model) -> unit
 
 type Canvas =
     static member Text(ctx: Context, style, text, x, y, ?font) =
@@ -75,17 +81,43 @@ type Canvas =
         render ctx
         ctx.restore()
 
-    static member Start<'Msg,'Model>
-            (canvasId: string, init: 'Model, tick: float->'Msg, update: Update<'Msg, 'Model>,
-             view: View<'Model>, ?subscribe: Browser.HTMLCanvasElement->('Msg->unit)->'Model->unit) =
+    static member Start<'Msg,'Model,'CacheModel>
+                    (initCanvas: unit -> Browser.HTMLCanvasElement,
+                     initModel: ('Msg->unit) -> CanvasControls<'Model, 'CacheModel> -> 'Model,
+                     cacheModel: 'Model -> 'CacheModel,
+                     tick: float -> 'Msg,
+                     update: Update<'Msg, 'Model>,
+                     view: View<'Model>) =
 
+        let BUFFER_LENGTH = 10000
+        let mutable idx = 0
+        let mutable paused = false
+        let mutable model = Unchecked.defaultof<'Model>
         let mainLoop: MainLoop = JsInterop.importAll "mainloop.js"
-        let canvasEl = Browser.document.getElementById(canvasId) :?> Browser.HTMLCanvasElement
+        let modelBuffer: 'CacheModel[] = Array.zeroCreate BUFFER_LENGTH
+        let canvasEl = initCanvas()
         let ctx = canvasEl.getContext_2d()
+
+        let controls =
+            { new CanvasControls<'Model, 'CacheModel> with
+                member __.IsPaused = paused
+                member __.TogglePause() =
+                    if paused then mainLoop.start() else mainLoop.stop()
+                    paused <- not paused
+                member __.RevertState(reverter) =
+                    idx <-
+                        if idx = 0
+                        then BUFFER_LENGTH - 1 // TODO: check if last element is null
+                        else idx - 1
+                    model <- reverter model modelBuffer.[idx]
+                    view model ctx
+            }
         let msgs = ResizeArray()
-        let mutable model = init
-        let dispatch msg = msgs.Add(msg)
-        subscribe |> Option.iter (fun f -> f canvasEl dispatch model)
+        let dispatch msg =
+            if not paused then // Ignore events when paused
+                msgs.Add(msg)
+        model <- initModel dispatch controls
+
         mainLoop
             .setBegin(fun _timestamp _delta ->
                 let msgs2 = Array.ofSeq msgs
@@ -93,14 +125,21 @@ type Canvas =
                 model <- (model, msgs2) ||> Array.fold update
             )
             .setUpdate(fun delta ->
-                model <- tick delta |> update model)
-            .setDraw(fun interpolationPercentage ->
-                view model ctx interpolationPercentage)
+                let msg = tick delta
+                model <- update model msg
+            )
+            .setDraw(fun _interpolationPercentage ->
+                view model ctx
+            )
             // TODO: Make the end function customizable
             // For default behaviour see https://github.com/IceCreamYou/MainLoop.js/blob/a499baae76d4197dbf8178877cbdd2b903a00dc8/demo/index.html#L210
             .setEnd(fun _fps panic ->
                 if panic then
                     let discardedTime = mainLoop.resetFrameDelta() |> System.Math.Round
-                    Browser.console.warn("Main loop panicked, probably because the browser tab was put in the background. Discarding (ms)", discardedTime))
+                    Browser.console.warn("Main loop panicked, probably because the browser tab was put in the background. Discarding (ms)", discardedTime)
+                else
+                    modelBuffer.[idx] <- cacheModel model
+                    idx <- if idx = (BUFFER_LENGTH - 1) then 0 else idx + 1
+            )
             .start()
         // mainLoop.setMaxAllowedFPS 20.

--- a/game2/src/util.js
+++ b/game2/src/util.js
@@ -1,0 +1,26 @@
+export function clone(o1) {
+    var o2 = {};
+    function deepClone(v) {
+        if (v === o1) {
+            return o2;
+        } else if (Array.isArray(v)) {
+            var ar = new Array(v.length);
+            for (var i = 0; i < v.length; i++) {
+                ar[i] = deepClone(v[i]);
+            }
+            return ar;
+        } else if (typeof v === "object") {
+            var v2 = {};
+            Object.keys(v).forEach(k => {
+                v2[k] = deepClone(v[k]);
+            });
+            return v2;
+        } else {
+            return v;
+        }
+    }
+    Object.keys(o1).forEach(k => {
+        o2[k] = deepClone(o1[k]);
+    });
+    return o2;
+}


### PR DESCRIPTION
@theimowski At the end I had many problems due to the mutability of matter.js and the circular references the objects contain (which prevent JSON serialization to communicate with redux devtools). I managed to get some kind of time travel but it only works backwards at the moment and after resuming the game I'm getting some strange behaviour in the player movement. Also, after doing the work I noticed you were working in a different folder 🤦‍♂️  so if you want to merge I have to move the changes to the other files.

What do you think? If you want to add it to the talk, I can rework the PR and try to add forward time travel. If you think it's too risky at this stage, you can just leave it for next year ;)

If you want to give it a try, run `npm start` in `game2` folder. Then hit `p` to pause the game, during pause you can use the left arrow to go back in time.

![timetravel](https://user-images.githubusercontent.com/8275461/47487619-11552000-d843-11e8-8c48-df35f864e394.gif)
